### PR TITLE
fix: align StateRegistryGenerator type discovery with UIStateNotifier

### DIFF
--- a/Assets/ECSReact/CHANGELOG.md
+++ b/Assets/ECSReact/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[0.1.6] - 2026-05-23
+
+### Fixed
+
+###### `StateRegistryGenerator` now discovers all `IGameState` types across all assemblies
+
+The editor tool was silently missing state types that `UIStateNotifierGenerator` found correctly. Two bugs in `discoverStateTypes()`: an assembly name filter that could exclude valid user assemblies, and a broken reflection-based `IsUnmanaged()` check that incorrectly rejected states containing Unity structs with internal pointer fields (e.g. `BlobAssetReference<T>`). Discovery logic is now fully aligned with `UIStateNotifierGenerator`.
+
 ## \[0.1.5] - 2026-03-18
 
 ### Changed

--- a/Assets/ECSReact/Editor/CodeGeneration/StateRegistryGenerator.cs
+++ b/Assets/ECSReact/Editor/CodeGeneration/StateRegistryGenerator.cs
@@ -168,50 +168,66 @@ namespace ECSReact.Editor.CodeGeneration
 
     private void discoverStateTypes()
     {
+      var previousGroups = namespaceGroups.ToDictionary(g => g.Key, g => g.Value);
       namespaceGroups.Clear();
 
-      var gameStateInterface = typeof(ECSReact.Core.IGameState);
-      var componentDataInterface = typeof(Unity.Entities.IComponentData);
+      var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-      var stateTypes = AppDomain.CurrentDomain.GetAssemblies()
-          .Where(a => !a.FullName.StartsWith("Unity") && !a.FullName.StartsWith("System"))
-          .SelectMany(a =>
-          {
-            try { return a.GetTypes(); } catch { return new Type[0]; }
-          })
-          .Where(t => t.IsValueType &&
-                     !t.IsAbstract &&
-                     !t.IsGenericType &&
-                     t.IsUnmanaged() &&
-                     gameStateInterface.IsAssignableFrom(t) &&
-                     componentDataInterface.IsAssignableFrom(t))
-          .OrderBy(t => t.Namespace ?? "")
-          .ThenBy(t => t.Name)
-          .ToList();
+      foreach (var assembly in assemblies) {
+        try {
+          var types = assembly.GetTypes()
+              .Where(t => t.IsValueType && !t.IsEnum && !t.IsGenericType)
+              .Where(t => typeof(Unity.Entities.IComponentData).IsAssignableFrom(t))
+              .Where(t => t.GetInterfaces().Any(i => i.Name == "IGameState"))
+              .ToList();
 
-      // Group by namespace
-      foreach (var stateType in stateTypes) {
-        string ns = stateType.Namespace ?? "Global";
+          foreach (var type in types) {
+            string ns = type.Namespace ?? "Global";
 
-        if (!namespaceGroups.ContainsKey(ns)) {
-          namespaceGroups[ns] = new NamespaceGroup
-          {
-            namespaceName = ns,
-            states = new List<StateTypeInfo>(),
-            isExpanded = true,
-            includeInGeneration = true
-          };
+            var stateInfo = new StateTypeInfo
+            {
+              stateType = type,
+              typeName = type.Name,
+              fullTypeName = type.FullName,
+              namespaceName = ns,
+              assemblyName = assembly.GetName().Name,
+              includeInGeneration = true
+            };
+
+            if (!namespaceGroups.ContainsKey(ns)) {
+              namespaceGroups[ns] = new NamespaceGroup
+              {
+                namespaceName = ns,
+                states = new List<StateTypeInfo>(),
+                isExpanded = true,
+                includeInGeneration = true
+              };
+            }
+
+            // Preserve previous checkbox state on re-discovery
+            if (previousGroups.TryGetValue(ns, out var previousGroup)) {
+              var previousState = previousGroup.states.FirstOrDefault(s => s.typeName == type.Name);
+              if (previousState != null) {
+                stateInfo.includeInGeneration = previousState.includeInGeneration;
+              }
+              namespaceGroups[ns].includeInGeneration = previousGroup.includeInGeneration;
+              namespaceGroups[ns].isExpanded = previousGroup.isExpanded;
+            }
+
+            namespaceGroups[ns].states.Add(stateInfo);
+          }
+        } catch (System.Reflection.ReflectionTypeLoadException ex) {
+          Debug.LogWarning($"[StateRegistryGenerator] Could not load types from assembly {assembly.GetName().Name}: {ex.Message}");
+        } catch (Exception ex) {
+          Debug.LogWarning($"[StateRegistryGenerator] Error processing assembly {assembly.GetName().Name}: {ex.Message}");
         }
-
-        namespaceGroups[ns].states.Add(new StateTypeInfo
-        {
-          stateType = stateType,
-          typeName = stateType.Name,
-          includeInGeneration = true
-        });
       }
 
-      Debug.Log($"[StateRegistryGenerator] Discovered {stateTypes.Count} state types across {namespaceGroups.Count} namespaces");
+      foreach (var group in namespaceGroups.Values) {
+        group.states = group.states.OrderBy(s => s.typeName).ToList();
+      }
+
+      Debug.Log($"[StateRegistryGenerator] Discovered {namespaceGroups.Values.Sum(g => g.states.Count)} state types across {namespaceGroups.Count} namespaces");
     }
 
     private void generateStateRegistry()
@@ -489,63 +505,4 @@ namespace ECSReact.Editor.CodeGeneration
     }
   }
 
-
-  // Extension to check if a type is unmanaged
-  public static class TypeExtensions
-  {
-    public static bool IsUnmanaged(this Type type)
-    {
-      if (!type.IsValueType)
-        return false;
-
-      // Check all fields recursively
-      foreach (var field in type.GetFields(System.Reflection.BindingFlags.Instance |
-                                          System.Reflection.BindingFlags.Public |
-                                          System.Reflection.BindingFlags.NonPublic)) {
-        var fieldType = field.FieldType;
-
-        // Skip if it's a primitive or enum
-        if (fieldType.IsPrimitive || fieldType.IsEnum)
-          continue;
-
-        // Check for common Unity unmanaged types
-        if (isKnownUnmanagedType(fieldType))
-          continue;
-
-        // For other value types, check recursively
-        if (fieldType.IsValueType) {
-          if (!IsUnmanaged(fieldType))
-            return false;
-        } else {
-          // Reference type found
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    private static bool isKnownUnmanagedType(Type type)
-    {
-      var typeName = type.FullName;
-
-      // Unity.Mathematics types
-      if (typeName.StartsWith("Unity.Mathematics."))
-        return true;
-
-      // Unity.Collections types
-      if (typeName.StartsWith("Unity.Collections.FixedString"))
-        return true;
-      if (typeName.StartsWith("Unity.Collections.FixedList"))
-        return true;
-
-      // Unity Entity type
-      if (typeName == "Unity.Entities.Entity")
-        return true;
-
-      // Add other known unmanaged types as needed
-
-      return false;
-    }
-  }
 }

--- a/Assets/ECSReact/package.json
+++ b/Assets/ECSReact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.ecsreact.core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "displayName": "ECSReact",
   "description": "A React-inspired unidirectional data flow architecture built on Unity's Entity Component System (ECS)",
   "unity": "6000.2",


### PR DESCRIPTION
## Summary

Fixes #9 — the State Registry Generator was silently missing state types that the UIStateNotifier Generator found correctly. Root cause was two bugs in `discoverStateTypes()`:

- **Assembly filter**: excluded any assembly whose `FullName` started with `"Unity"` or `"System"`, which could silently drop valid user state types depending on `.asmdef` naming
- **Broken `IsUnmanaged()` check**: a custom reflection-based unmanaged check incorrectly rejected state types containing Unity structs with internal pointer fields (e.g. `BlobAssetReference<T>`, `NativeHashMap`). Unity already enforces `IComponentData` unmanagededness at compile time, making this runtime check both redundant and wrong.

The fix rewrites `discoverStateTypes()` to exactly match `UIStateNotifierGenerator`'s approach, and removes the now-unused `TypeExtensions` class (`IsUnmanaged`, `isKnownUnmanagedType`).

`AutoGenerateAll` was audited and required no changes — it already used the correct pattern.

## Changes

- **`StateRegistryGenerator.discoverStateTypes()`**: scan all assemblies, drop `IsUnmanaged()` filter, use name-based interface check, add per-assembly `ReflectionTypeLoadException` handling, preserve checkbox state across re-discoveries, sort results post-grouping
- **`TypeExtensions` class removed**: `IsUnmanaged()` and `isKnownUnmanagedType()` were only called by the old discovery code

## Test plan

- [ ] Open State Registry Generator and click Discover State Types — confirm it now finds the same namespaces and state count as UIStateNotifier Generator
- [ ] Verify `Terrabomb.State` namespace (`AssetLibraryState`, `TurretCooldownState`, `TurretHealthState`) appears alongside `Terrabomb.UI.Selection`
- [ ] Re-click Discover State Types and confirm previously checked/unchecked boxes are preserved
- [ ] Generate State Registry and confirm output compiles without errors

https://claude.ai/code/session_01DuEtEJnnGfn1LJBPkKHAtB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuEtEJnnGfn1LJBPkKHAtB)_